### PR TITLE
Fix issue where purges do not have a filter to target a specific user.

### DIFF
--- a/consts/purge.go
+++ b/consts/purge.go
@@ -8,6 +8,7 @@ const (
 	PURGE_BOT          PurgeType = "bots"
 	PURGE_IMAGE        PurgeType = "images"
 	PURGE_STRING       PurgeType = "string"
-	PURGE_USER         PurgeType = "users"
+	PURGE_USER         PurgeType = "user"
+	PURGE_USERS        PurgeType = "users"
 	PURGE_VIDEO        PurgeType = "videos"
 )


### PR DESCRIPTION
[Added PURGE_USER to be separate from PURGE_USERS](https://github.com/blackmesadev/black-mesa/commit/cb6acb0266cedd36061973ecfc651da906693d0f), both with the string "user" and "users" respectively. However for functionality, "user" is not needed if Black Mesa detects an ID in the message, it will automatically set the Purge Type to PURGE_USER.

[Fix issue where purges do not have a filter to target a specific user](https://github.com/blackmesadev/black-mesa/commit/9bb925b4ee87bd29b3a90ac7383aa97285a64d4f), simple change, copied from the old PurgeUser, just changed the logic to iterate over the id list and add to the bulk delete slice based on that.

