### PR TITLE
Fix double DM message send when striking people.

### DIFF
--- a/modules/moderation/strike.go
+++ b/modules/moderation/strike.go
@@ -76,11 +76,6 @@ func StrikeCmd(s *discordgo.Session, conf *structs.Config, m *discordgo.Message,
 		timeExpiry = time.Unix(duration, 0)
 		timeUntil = time.Until(timeExpiry).Round(time.Second)
 
-		guild, err := s.Guild(m.GuildID)
-		member, err := s.GuildMember(m.GuildID, id)
-		if err == nil {
-			s.UserMessageSendEmbed(id, CreatePunishmentEmbed(member, guild, m.Author, reason, &timeExpiry, permStrike, "Striked"))
-		}
 		if err != nil {
 			log.Println(err)
 			unableStrike = append(unableStrike, id)

--- a/modules/moderation/strike.go
+++ b/modules/moderation/strike.go
@@ -76,11 +76,11 @@ func StrikeCmd(s *discordgo.Session, conf *structs.Config, m *discordgo.Message,
 		timeExpiry = time.Unix(duration, 0)
 		timeUntil = time.Until(timeExpiry).Round(time.Second)
 
-		guild, err := s.Guild(m.GuildID)
-		member, err := s.GuildMember(m.GuildID, id)
-		if err == nil {
+		//guild, err := s.Guild(m.GuildID)
+		//member, err := s.GuildMember(m.GuildID, id)
+		/*if err == nil {
 			s.UserMessageSendEmbed(id, CreatePunishmentEmbed(member, guild, m.Author, reason, &timeExpiry, permStrike, "Striked"))
-		}
+		}*/
 		if err != nil {
 			log.Println(err)
 			unableStrike = append(unableStrike, id)

--- a/modules/moderation/strike.go
+++ b/modules/moderation/strike.go
@@ -76,11 +76,11 @@ func StrikeCmd(s *discordgo.Session, conf *structs.Config, m *discordgo.Message,
 		timeExpiry = time.Unix(duration, 0)
 		timeUntil = time.Until(timeExpiry).Round(time.Second)
 
-		//guild, err := s.Guild(m.GuildID)
-		//member, err := s.GuildMember(m.GuildID, id)
-		/*if err == nil {
+		guild, err := s.Guild(m.GuildID)
+		member, err := s.GuildMember(m.GuildID, id)
+		if err == nil {
 			s.UserMessageSendEmbed(id, CreatePunishmentEmbed(member, guild, m.Author, reason, &timeExpiry, permStrike, "Striked"))
-		}*/
+		}
 		if err != nil {
 			log.Println(err)
 			unableStrike = append(unableStrike, id)


### PR DESCRIPTION
This pr fixes the supposed "double strike" people have been complaining about in the main server. For some reason Black Mesa sent the same embed twice to a person that had been striked, leading some to believe they have been unfairly striked twice for the same thing.